### PR TITLE
Fix: Commands not recognized properly with prefix containing uppercase letters

### DIFF
--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -802,7 +802,7 @@ class CommandHandler extends AkairoHandler {
 
         if (start === undefined) return this.parseCommandWithOverwrittenPrefixes(message);
 
-        const startIndex = message.content.toLowerCase().indexOf(start) + start.length;
+        const startIndex = message.content.toLowerCase().indexOf(start.toLowerCase()) + start.length;
         const argsIndex = message.content.slice(startIndex).search(/\S/) + start.length;
         const name = message.content.slice(argsIndex).split(/\s{1,}|\n{1,}/)[0];
         const command = this.findCommand(name);


### PR DESCRIPTION
## The bug:
Using a space after a prefix containing an uppercase letter will not be recognized as command.  

## Details:
In `const startIndex = message.content.toLowerCase().indexOf(start) + start.length`
assuming the prefix: `Bot` and the message `Bot ping`  

`start` being the prefix, `message.content.toLowerCase().indexOf(start)` will be -1 (due to no match) but should be: 0 (found at index 0)
resulting in `startIndex` to be -1 + 3 instead of 0 + 3
This results into the command being searched for to be `_ping` (leading space) instead of `ping` (no leading space) and thus the command not being executed.

## Fix:
`start.toLowerCase()` to allow the match for prefixes containing uppercase letters
