### PR TITLE
Throw an error when discord.js version is not the one needed by akairo to work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .git
+.idea
 .vscode
 test/auth.json
 test/db.sqlite

--- a/src/struct/AkairoClient.js
+++ b/src/struct/AkairoClient.js
@@ -1,5 +1,7 @@
-const { Client } = require('discord.js');
+const { Client, version } = require('discord.js');
 const ClientUtil = require('./ClientUtil');
+
+const neededVersion = '12.0.0-dev';
 
 /**
  * The Akairo framework client.
@@ -11,6 +13,8 @@ const ClientUtil = require('./ClientUtil');
 class AkairoClient extends Client {
     constructor(options = {}, clientOptions) {
         super(clientOptions || options);
+
+        if (version !== neededVersion) throw new Error('Version of discord.js needed: ' + neededVersion + '. Installed version: ' + version);
 
         const { ownerID = '' } = options;
 


### PR DESCRIPTION
This is probably not the best way to do this, but here is the idea.
The actual errors that happen when discord.js is stable and akairo in master for example, are pretty much hard to spot.