### PR TITLE
docs: call setEmitters before load

### DIFF
--- a/docs/basics/listeners.md
+++ b/docs/basics/listeners.md
@@ -93,6 +93,8 @@ this.listenerHandler.setEmitters({
 });
 ```
 
+Note: You have to call `setEmitters` before `loadAll` or Akairo will not be able to resolve your emitters.
+
 ### Blocked Commands
 
 Remember the `reason` for inhibitors in previous tutorial?  

--- a/docs/listeners/emitters.md
+++ b/docs/listeners/emitters.md
@@ -13,6 +13,8 @@ this.listenerHandler.setEmitters({
 });
 ```
 
+Note: You have to call `setEmitters` before `load` or `loadAll` so that Akairo will be able to resolve your emitters.
+
 The key will be the emitter's name, and the value is the emitter itself.  
 Now, we can use a listener on the process:  
 


### PR DESCRIPTION
Suggest to add additional documentation to the guide, to call `setEmitters` before `load` or `loadAll`. Otherwise it will trigger `AkairoError [INVALID_TYPE]: Value of 'emitter' was not an EventEmitter`. API users should not usually have to concern themselves with what is going on behind the scenes, therefore documentation should state if certain steps have to be carried out in a specific order.