### PR TITLE
Add an option to CommandHandler: onlyStoreCommands

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -556,7 +556,7 @@ declare module 'discord-akairo' {
         ignorePermissions?: Snowflake | Snowflake[] | IgnoreCheckPredicate;
         prefix?: string | string[] | PrefixSupplier;
         storeMessages?: boolean;
-        public onlyStoreCommmands: boolean;
+        onlyStoreCommmands: boolean;
     } & AkairoHandlerOptions;
 
     export type ContentParserResult = {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -213,7 +213,6 @@ declare module 'discord-akairo' {
         public prompts: Collection<string, Set<string>>;
         public resolver: TypeResolver;
         public storeMessage: boolean;
-        public onlyStoreCommmands: boolean;
 
         public add(filename: string): Command;
         public addPrompt(channel: Channel, user: User): void;
@@ -557,6 +556,7 @@ declare module 'discord-akairo' {
         ignorePermissions?: Snowflake | Snowflake[] | IgnoreCheckPredicate;
         prefix?: string | string[] | PrefixSupplier;
         storeMessages?: boolean;
+        public onlyStoreCommmands: boolean;
     } & AkairoHandlerOptions;
 
     export type ContentParserResult = {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -213,6 +213,7 @@ declare module 'discord-akairo' {
         public prompts: Collection<string, Set<string>>;
         public resolver: TypeResolver;
         public storeMessage: boolean;
+        public onlyStoreCommmands: boolean;
 
         public add(filename: string): Command;
         public addPrompt(channel: Channel, user: User): void;

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -351,10 +351,11 @@ class CommandHandler extends AkairoHandler {
             if (await this.runAllTypeInhibitors(message)) {
                 return false;
             }
-
+            let parsed = await this.parseCommand(message);
+            
             if (this.commandUtil) {
                 if(this.onlyStoreCommands) {
-                    if(!message.util.parsed.command) return;
+                    if(!parsed.command) return;
                 }
                 if (this.commandUtils.has(message.id)) {
                     message.util = this.commandUtils.get(message.id);
@@ -367,8 +368,6 @@ class CommandHandler extends AkairoHandler {
             if (await this.runPreTypeInhibitors(message)) {
                 return false;
             }
-
-            let parsed = await this.parseCommand(message);
             if (!parsed.command) {
                 const overParsed = await this.parseCommandOverwrittenPrefixes(message);
                 if (overParsed.command || (parsed.prefix == null && overParsed.prefix != null)) {

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -103,11 +103,13 @@ class CommandHandler extends AkairoHandler {
          * @type {boolean}
          */
         this.storeMessages = Boolean(storeMessages);
+        
         /**
          * Whether or not to store messages that aren't commands in CommandUtil.
          * @type {boolean}
          */
         this.onlyStoreCommands = Boolean(onlyStoreCommands);
+        
         /**
          * Whether or not `message.util` is assigned.
          * @type {boolean}

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -349,13 +349,13 @@ class CommandHandler extends AkairoHandler {
             if (await this.runAllTypeInhibitors(message)) {
                 return false;
             }
-            let parsed = await this.parseCommand(message);
-            
+            let parsed = await this.parseCommand(message)
+
             if (this.commandUtil) {
-                if(this.onlyStoreCommands) {
-                    if(!parsed.command) return false;
+                if (this.onlyStoreCommands) {
+                    if (!parsed.command) return false;
                 }
-                
+
                 if (this.commandUtils.has(message.id)) {
                     message.util = this.commandUtils.get(message.id);
                 } else {

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -355,7 +355,7 @@ class CommandHandler extends AkairoHandler {
             
             if (this.commandUtil) {
                 if(this.onlyStoreCommands) {
-                    if(!parsed.command) return;
+                    if(!parsed.command) return false;
                 }
                 if (this.commandUtils.has(message.id)) {
                     message.util = this.commandUtils.get(message.id);

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -103,13 +103,11 @@ class CommandHandler extends AkairoHandler {
          * @type {boolean}
          */
         this.storeMessages = Boolean(storeMessages);
-        
         /**
          * Whether or not to store messages that aren't commands in CommandUtil.
          * @type {boolean}
          */
-        this.onlyStoreCommands = Boolean(onlyStoreCommands)
-        
+        this.onlyStoreCommands = Boolean(onlyStoreCommands);
         /**
          * Whether or not `message.util` is assigned.
          * @type {boolean}
@@ -357,6 +355,7 @@ class CommandHandler extends AkairoHandler {
                 if(this.onlyStoreCommands) {
                     if(!parsed.command) return false;
                 }
+                
                 if (this.commandUtils.has(message.id)) {
                     message.util = this.commandUtils.get(message.id);
                 } else {

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -353,6 +353,9 @@ class CommandHandler extends AkairoHandler {
             }
 
             if (this.commandUtil) {
+                if(this.onlyStoreCommands) {
+                    if(!message.util.parsed.command) return;
+                }
                 if (this.commandUtils.has(message.id)) {
                     message.util = this.commandUtils.get(message.id);
                 } else {

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -103,7 +103,11 @@ class CommandHandler extends AkairoHandler {
          * @type {boolean}
          */
         this.storeMessages = Boolean(storeMessages);
-
+        /**
+         * Whether or not to store messages that aren't commands in CommandUtil.
+         * @type {boolean}
+         */
+        this.onlyStoreCommands = Boolean(onlyStoreCommands);
         /**
          * Whether or not `message.util` is assigned.
          * @type {boolean}

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -108,7 +108,7 @@ class CommandHandler extends AkairoHandler {
          * Whether or not to store messages that aren't commands in CommandUtil.
          * @type {boolean}
          */
-        this.onlyStoreCommands = Boolean(onlyStoreCommands);
+        this.onlyStoreCommands = Boolean(onlyStoreCommands)
         
         /**
          * Whether or not `message.util` is assigned.

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -349,7 +349,7 @@ class CommandHandler extends AkairoHandler {
             if (await this.runAllTypeInhibitors(message)) {
                 return false;
             }
-            let parsed = await this.parseCommand(message)
+            let parsed = await this.parseCommand(message);
 
             if (this.commandUtil) {
                 if (this.onlyStoreCommands) {

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -27,6 +27,7 @@ class CommandHandler extends AkairoHandler {
         handleEdits = false,
         storeMessages = false,
         commandUtil,
+        onlyStoreCommands = true,
         commandUtilLifetime = 3e5,
         commandUtilSweepInterval = 3e5,
         defaultCooldown = 0,

--- a/src/struct/commands/CommandUtil.js
+++ b/src/struct/commands/CommandUtil.js
@@ -66,13 +66,10 @@ class CommandUtil {
     /**
      * Adds client prompt or user reply to messages.
      * @param {Message|Message[]} message - Message to add.
-     * @returns {Message|Message[]|any}
+     * @returns {Message|Message[]}
      */
     addMessage(message) {
         if (this.handler.storeMessages) {
-            if(this.handler.onlyStoreCommands) {
-                if(!message.util.parsed.command) return;
-            }
             if (Array.isArray(message)) {
                 for (const msg of message) {
                     this.messages.set(msg.id, msg);

--- a/src/struct/commands/CommandUtil.js
+++ b/src/struct/commands/CommandUtil.js
@@ -66,12 +66,12 @@ class CommandUtil {
     /**
      * Adds client prompt or user reply to messages.
      * @param {Message|Message[]} message - Message to add.
-     * @returns {Message|Message[]}
+     * @returns {Message|Message[]|any}
      */
     addMessage(message) {
         if (this.handler.storeMessages) {
             if(this.handler.onlyStoreCommands) {
-                if(!message.util.parsed.commands) return;
+                if(!message.util.parsed.command) return;
             }
             if (Array.isArray(message)) {
                 for (const msg of message) {

--- a/src/struct/commands/CommandUtil.js
+++ b/src/struct/commands/CommandUtil.js
@@ -70,6 +70,9 @@ class CommandUtil {
      */
     addMessage(message) {
         if (this.handler.storeMessages) {
+            if(this.handler.onlyStoreCommands) {
+                if(!message.util.parsed.commands) return;
+            }
             if (Array.isArray(message)) {
                 for (const msg of message) {
                     this.messages.set(msg.id, msg);


### PR DESCRIPTION
This option means that CommandHandler.commandUtils will only store valid commands, that way there is less unnecessary things cached which means less ram usage which means that you can allow a bigger commandUtilLifetime and sweepInterval.