### PR TITLE
bring checkGuild inline with the rest of the checks

### DIFF
--- a/src/struct/ClientUtil.js
+++ b/src/struct/ClientUtil.js
@@ -310,7 +310,7 @@ class ClientUtil {
      * @param {boolean} [wholeWord=false] - Makes checking by name match full word only.
      * @returns {boolean}
      */
-    checkGuild(text, guild, caseSensitive, wholeWord) {
+    checkGuild(text, guild, caseSensitive = false, wholeWord = false) {
         if (guild.id === text) return true;
 
         text = caseSensitive ? text : text.toLowerCase();


### PR DESCRIPTION
The rest of the check functions default caseSensitive and wholeWord to false, except checkGuild, this aims to fix that