### PR TITLE
Fix incorrectly skipping setLastResponse when using CommandUtil.send

### DIFF
--- a/src/struct/CommandUtil.js
+++ b/src/struct/CommandUtil.js
@@ -79,8 +79,8 @@ class CommandUtil {
      */
     send(content, options) {
         [content, options] = this.constructor.swapOptions(content, options);
-        const hadFiles = (options.file || options.files)
-        || (options.embed && (options.embed.file || options.embed.files));
+        const hadFiles = (options.file || (options.files || []).length > 0)
+        || (options.embed && (options.embed.file || (options.embed.files || []).length > 0));
 
         if (this.shouldEdit && (this.command ? this.command.editable : true) && (hadFiles || !this.lastResponse.attachments.size)) {
             return this.lastResponse.edit(content, options);


### PR DESCRIPTION
I encountered a bug with sending an embed through message.util.send, and then later trying to edit it through message.util.edit. The edit call would error internally because lastResponse was null even after the send completed. This is due to discord.js returning an empty array for embed.files, rather than null. The empty array cascaded to the local `hadFiles` and was interpreted as truthy on line 90, skipping the setLastResponse call.
`if (hadFiles || (this.lastResponse && this.lastResponse.attachments.size)) return sent;`

I haven't tested anything about this bug in version 8, as CommandUtil is very different there.