### PR TITLE
Updated docs(TypeCasters) to master version

### DIFF
--- a/docs/arguments/custom.md
+++ b/docs/arguments/custom.md
@@ -7,7 +7,7 @@ To add a new type:
 
 ```js
 this.commandHandler = new CommandHandler(this, { /* Options here */ });
-this.commandHandler.resolver.addType('pokemon', phrase => {
+this.commandHandler.resolver.addType('pokemon', (message, phrase) => {
     if (!phrase) return null;
 
     for (const pokemon of pokemonList) {
@@ -30,7 +30,7 @@ This means we need access to the guild through the message.
 Good thing the second parameter is the message!  
 
 ```js
-this.commandHandler.resolver.addType('colorRole', (phrase, message) => {
+this.commandHandler.resolver.addType('colorRole', (message, phrase) => {
     if (!phrase) return null;
 
     const roles = {
@@ -52,10 +52,10 @@ To get another type for use, you use the `type` method on `TypeResolver`.
 The following gives the `member` type and we can use as part of another type.  
 
 ```js
-this.commandHandler.resolver.addType('moderator', (phrase, message) => {
+this.commandHandler.resolver.addType('moderator', (message, phrase) => {
     if (!phrase) return null;
     const memberType = this.commandHandler.resolver.type('member');
-    const member = memberType(phrase, message);
+    const member = memberType(message, phrase);
     if (!member.roles.has('222089067028807682')) return null;
     return member;
 });

--- a/docs/arguments/custom.md
+++ b/docs/arguments/custom.md
@@ -27,7 +27,7 @@ Simply do `type: 'pokemon'` for an argument and everything will work as expected
 
 Let's say we want to add a type that would get a role based on the input.  
 This means we need access to the guild through the message.  
-Good thing the second parameter is the message!  
+Good thing the first parameter is the message!  
 
 ```js
 this.commandHandler.resolver.addType('colorRole', (message, phrase) => {

--- a/docs/arguments/functions.md
+++ b/docs/arguments/functions.md
@@ -80,7 +80,7 @@ class RollCommand extends Command {
             args: [
                 {
                     id: 'amount',
-                    type: phrase => {
+                    type: (message, phrase) => {
                         if (!phrase || isNaN(phrase)) return null;
                         const num = parseInt(phrase);
                         if (num < 1 || num > 100) return null;


### PR DESCRIPTION
### Why to merge
TypeCasters docs were outdated, and were only applied to the stable version of TypeCasters.
- Updated docs for `docs/arguments/custom.md`
- Updated docs for `docs/arguments/functions.md`

While there might be other outdated documentation, I wanted to fix this first cause it confused a lot of people who install master for the first time (and only read the guide and not the actual reference).

### Issue
One more thing, I was going to make an issue about this, but it really doesn't belong to this repo.

The links that are used to link between pages, for example `docs/arguments/functions.md#119`, they do work on GitHub, but they don't work on the GitHub pages website. So... you might do something in discord.js's Vue app since it's a virtual DOM/single- page app (don't know what to call it) and it considers `./` as the index page, and not the page you're on.  
Meaning, doing `./compose.md` from `functions.md` will only forward to  
https://discord-akairo.github.io/compose.md (which does not exist)
but not https://discord-akairo.github.io/#/docs/main/master/arguments/compose.  
So yeah you might want to do something about that. 👀

Love your work <3 and good luck with your projects :)