### PR TITLE
refactor(typings): types to interfaces

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -441,29 +441,29 @@ declare module 'discord-akairo' {
         public static isPromise(value: any): boolean;
     }
 
-    export type AkairoHandlerOptions = {
+    export interface AkairoHandlerOptions {
         automateCategories?: boolean;
         classToHandle?: Function;
         directory?: string;
         extensions?: string[] | Set<string>;
         loadFilter?: LoadPredicate;
-    };
+    }
 
-    export type AkairoModuleOptions = {
+    export interface AkairoModuleOptions {
         category?: string;
-    };
+    }
 
-    export type AkairoOptions = {
+    export interface AkairoOptions {
         ownerID?: Snowflake | Snowflake[];
-    };
+    }
 
-    export type DefaultArgumentOptions = {
+    export interface DefaultArgumentOptions {
         prompt?: ArgumentPromptOptions;
         otherwise?: StringResolvable | MessageOptions | MessageAdditions | OtherwiseContentSupplier;
         modifyOtherwise?: OtherwiseContentModifier;
-    };
+    }
 
-    export type ArgumentOptions = {
+    export interface ArgumentOptions {
         default?: DefaultValueSupplier | any;
         description?: StringResolvable;
         id?: string;
@@ -477,17 +477,17 @@ declare module 'discord-akairo' {
         prompt?: ArgumentPromptOptions | boolean;
         type?: ArgumentType | ArgumentTypeCaster;
         unordered?: boolean | number | number[];
-    };
+    }
 
-    export type ArgumentPromptData = {
+    export interface ArgumentPromptData {
         infinite: boolean;
         message: Message;
         retries: number;
         phrase: string;
         failure: void | (Flag & { value: any });
-    };
+    }
 
-    export type ArgumentPromptOptions = {
+    export interface ArgumentPromptOptions {
         breakout?: boolean;
         cancel?: StringResolvable | MessageOptions | MessageAdditions | PromptContentSupplier;
         cancelWord?: string;
@@ -506,15 +506,15 @@ declare module 'discord-akairo' {
         stopWord?: string;
         time?: number;
         timeout?: StringResolvable | MessageOptions | MessageAdditions | PromptContentSupplier;
-    };
+    }
 
-    export type ArgumentRunnerState = {
+    export interface ArgumentRunnerState {
         index: number;
         phraseIndex: number;
         usedIndices: Set<number>;
-    };
+    }
 
-    export type CommandOptions = {
+    export interface CommandOptions extends AkairoModuleOptions {
         aliases?: string[];
         args?: ArgumentOptions[] | ArgumentGenerator;
         argumentDefaults?: DefaultArgumentOptions;
@@ -538,9 +538,9 @@ declare module 'discord-akairo' {
         typing?: boolean;
         userPermissions?: PermissionResolvable | PermissionResolvable[] | MissingPermissionSupplier;
         quoted?: boolean;
-    } & AkairoModuleOptions;
+    }
 
-    export type CommandHandlerOptions = {
+    export interface CommandHandlerOptions extends AkairoHandlerOptions {
         aliasReplacement?: RegExp;
         allowMention?: boolean | MentionPrefixPredicate;
         argumentDefaults?: DefaultArgumentOptions;
@@ -556,50 +556,50 @@ declare module 'discord-akairo' {
         ignorePermissions?: Snowflake | Snowflake[] | IgnoreCheckPredicate;
         prefix?: string | string[] | PrefixSupplier;
         storeMessages?: boolean;
-    } & AkairoHandlerOptions;
+    }
 
-    export type ContentParserResult = {
+    export interface ContentParserResult {
         all: StringData[];
         phrases: StringData[];
         flags: StringData[];
         optionFlags: StringData[];
-    };
+    }
 
-    export type CooldownData = {
+    export interface CooldownData {
         end: number;
         timer: NodeJS.Timer;
         uses: number;
-    };
+    }
 
-    export type FailureData = {
+    export interface FailureData {
         phrase: string;
         failure: void | (Flag & { value: any });
-    };
+    }
 
-    export type InhibitorOptions = {
+    export interface InhibitorOptions extends AkairoModuleOptions {
         reason?: string;
         type?: string;
         priority?: number;
-    } & AkairoModuleOptions;
+    }
 
-    export type ListenerOptions = {
+    export interface ListenerOptions extends AkairoModuleOptions {
         emitter: string | EventEmitter;
         event: string;
         type?: string;
-    } & AkairoModuleOptions;
+    }
 
-    export type ParsedComponentData = {
+    export interface ParsedComponentData {
         afterPrefix?: string;
         alias?: string;
         command?: Command;
         content?: string;
         prefix?: string;
-    };
+    }
 
-    export type ProviderOptions = {
+    export interface ProviderOptions {
         dataColumn?: string;
         idColumn?: string;
-    };
+    }
 
     export type StringData = {
         type: 'Phrase';
@@ -669,7 +669,7 @@ declare module 'discord-akairo' {
 
     export type RegexSupplier = (message: Message) => RegExp;
 
-    export const Constants: {
+    export interface Constants {
         ArgumentMatches: {
             PHRASE: 'phrase',
             FLAG: 'flag',
@@ -753,7 +753,7 @@ declare module 'discord-akairo' {
             GUILD: 'guild',
             DM: 'dm'
         }
-    };
+    }
 
     export const version: string;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -671,88 +671,88 @@ declare module 'discord-akairo' {
 
     export interface Constants {
         ArgumentMatches: {
-            PHRASE: 'phrase',
-            FLAG: 'flag',
-            OPTION: 'option',
-            REST: 'rest',
-            SEPARATE: 'separate',
-            TEXT: 'text',
-            CONTENT: 'content',
-            REST_CONTENT: 'restContent',
-            NONE: 'none'
-        },
+            PHRASE: 'phrase';
+            FLAG: 'flag';
+            OPTION: 'option';
+            REST: 'rest';
+            SEPARATE: 'separate';
+            TEXT: 'text';
+            CONTENT: 'content';
+            REST_CONTENT: 'restContent';
+            NONE: 'none';
+        };
         ArgumentTypes: {
-            STRING: 'string',
-            LOWERCASE: 'lowercase',
-            UPPERCASE: 'uppercase',
-            CHAR_CODES: 'charCodes',
-            NUMBER: 'number',
-            INTEGER: 'integer',
-            BIGINT: 'bigint',
-            EMOJINT: 'emojint',
-            URL: 'url',
-            DATE: 'date',
-            COLOR: 'color',
-            USER: 'user',
-            USERS: 'users',
-            MEMBER: 'member',
-            MEMBERS: 'members',
-            RELEVANT: 'relevant',
-            RELEVANTS: 'relevants',
-            CHANNEL: 'channel',
-            CHANNELS: 'channels',
-            TEXT_CHANNEL: 'textChannel',
-            TEXT_CHANNELS: 'textChannels',
-            VOICE_CHANNEL: 'voiceChannel',
-            VOICE_CHANNELS: 'voiceChannels',
-            CATEGORY_CHANNEL: 'categoryChannel',
-            CATEGORY_CHANNELS: 'categoryChannels',
-            NEWS_CHANNEL: 'newsChannel',
-            NEWS_CHANNELS: 'newsChannels',
-            STORE_CHANNEL: 'storeChannel',
-            STORE_CHANNELS: 'storeChannels',
-            ROLE: 'role',
-            ROLES: 'roles',
-            EMOJI: 'emoji',
-            EMOJIS: 'emojis',
-            GUILD: 'guild',
-            GUILDS: 'guilds',
-            MESSAGE: 'message',
-            GUILD_MESSAGE: 'guildMessage',
-            INVITE: 'invite',
-            MEMBER_MENTION: 'memberMention',
-            CHANNEL_MENTION: 'channelMention',
-            ROLE_MENTION: 'roleMention',
-            EMOJI_MENTION: 'emojiMention',
-            COMMAND_ALIAS: 'commandAlias',
-            COMMAND: 'command',
-            INHIBITOR: 'inhibitor',
-            LISTENER: 'listener'
-        },
+            STRING: 'string';
+            LOWERCASE: 'lowercase';
+            UPPERCASE: 'uppercase';
+            CHAR_CODES: 'charCodes';
+            NUMBER: 'number';
+            INTEGER: 'integer';
+            BIGINT: 'bigint';
+            EMOJINT: 'emojint';
+            URL: 'url';
+            DATE: 'date';
+            COLOR: 'color';
+            USER: 'user';
+            USERS: 'users';
+            MEMBER: 'member';
+            MEMBERS: 'members';
+            RELEVANT: 'relevant';
+            RELEVANTS: 'relevants';
+            CHANNEL: 'channel';
+            CHANNELS: 'channels';
+            TEXT_CHANNEL: 'textChannel';
+            TEXT_CHANNELS: 'textChannels';
+            VOICE_CHANNEL: 'voiceChannel';
+            VOICE_CHANNELS: 'voiceChannels';
+            CATEGORY_CHANNEL: 'categoryChannel';
+            CATEGORY_CHANNELS: 'categoryChannels';
+            NEWS_CHANNEL: 'newsChannel';
+            NEWS_CHANNELS: 'newsChannels';
+            STORE_CHANNEL: 'storeChannel';
+            STORE_CHANNELS: 'storeChannels';
+            ROLE: 'role';
+            ROLES: 'roles';
+            EMOJI: 'emoji';
+            EMOJIS: 'emojis';
+            GUILD: 'guild';
+            GUILDS: 'guilds';
+            MESSAGE: 'message';
+            GUILD_MESSAGE: 'guildMessage';
+            INVITE: 'invite';
+            MEMBER_MENTION: 'memberMention';
+            CHANNEL_MENTION: 'channelMention';
+            ROLE_MENTION: 'roleMention';
+            EMOJI_MENTION: 'emojiMention';
+            COMMAND_ALIAS: 'commandAlias';
+            COMMAND: 'command';
+            INHIBITOR: 'inhibitor';
+            LISTENER: 'listener';
+        };
         AkairoHandlerEvents: {
-            LOAD: 'load',
-            REMOVE: 'remove'
-        },
+            LOAD: 'load';
+            REMOVE: 'remove';
+        };
         CommandHandlerEvents: {
-            MESSAGE_BLOCKED: 'messageBlocked',
-            MESSAGE_INVALID: 'messageInvalid',
-            COMMAND_BLOCKED: 'commandBlocked',
-            COMMAND_STARTED: 'commandStarted',
-            COMMAND_FINISHED: 'commandFinished',
-            COMMAND_CANCELLED: 'commandCancelled',
-            COMMAND_LOCKED: 'commandLocked',
-            MISSING_PERMISSIONS: 'missingPermissions',
-            COOLDOWN: 'cooldown',
-            IN_PROMPT: 'inPrompt',
-            ERROR: 'error'
-        },
+            MESSAGE_BLOCKED: 'messageBlocked';
+            MESSAGE_INVALID: 'messageInvalid';
+            COMMAND_BLOCKED: 'commandBlocked';
+            COMMAND_STARTED: 'commandStarted';
+            COMMAND_FINISHED: 'commandFinished';
+            COMMAND_CANCELLED: 'commandCancelled';
+            COMMAND_LOCKED: 'commandLocked';
+            MISSING_PERMISSIONS: 'missingPermissions';
+            COOLDOWN: 'cooldown';
+            IN_PROMPT: 'inPrompt';
+            ERROR: 'error';
+        };
         BuiltInReasons: {
-            CLIENT: 'client',
-            BOT: 'bot',
-            OWNER: 'owner',
-            GUILD: 'guild',
-            DM: 'dm'
-        }
+            CLIENT: 'client';
+            BOT: 'bot';
+            OWNER: 'owner';
+            GUILD: 'guild';
+            DM: 'dm';
+        };
     }
 
     export const version: string;


### PR DESCRIPTION
This is important so you can overwrite for example the `prefix` key in `CommandHandlerOptions` to not always have typecast it with `(this.handler.prefix as PrefixSupplier)(msg);` all over the place.

```ts
declare module 'discord-akairo' {
    interface CommandHandlerOptions {
        prefix: PrefixSupplier
    }
}
```