### PR TITLE
Addition of ClientUtil#webhook

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,7 +5,8 @@ declare module 'discord-akairo' {
         MessageAdditions, MessageEditOptions, MessageOptions,
         User, UserResolvable, GuildMember,
         Channel, Role, Emoji, Guild,
-        PermissionResolvable, StringResolvable, Snowflake
+        PermissionResolvable, StringResolvable, Snowflake,
+        WebhookClient
     } from 'discord.js';
 
     import { EventEmitter } from 'events';
@@ -146,6 +147,7 @@ declare module 'discord-akairo' {
         public resolveRoles(text: string, roles: Collection<Snowflake, Role>, caseSensitive?: boolean, wholeWord?: boolean): Collection<Snowflake, Role>;
         public resolveUser(text: string, users: Collection<Snowflake, User>, caseSensitive?: boolean, wholeWord?: boolean): User;
         public resolveUsers(text: string, users: Collection<Snowflake, User>, caseSensitive?: boolean, wholeWord?: boolean): Collection<Snowflake, User>;
+        public webhook(link: string): WebhookClient | null;
     }
 
     export class Command extends AkairoModule {

--- a/src/struct/ClientUtil.js
+++ b/src/struct/ClientUtil.js
@@ -1,4 +1,4 @@
-const { Collection, MessageAttachment, MessageEmbed, Permissions } = require('discord.js');
+const { Collection, MessageAttachment, MessageEmbed, Permissions, WebhookClient } = require('discord.js');
 
 /**
  * Client utilities to help with common tasks.
@@ -397,6 +397,19 @@ class ClientUtil {
      */
     collection(iterable) {
         return new Collection(iterable);
+    }
+    
+    /**
+     * Makes a WebhookClient.
+     * @param {string} [link] - The webhook link.
+     * @returns {Collection}
+     */
+    webhook(link) {
+        const parts = link.split('/');
+        const id = parts[parts.length - 2];
+        const token = parts[parts.length - 1];
+        if (!id || !token) return null;
+        return new WebhookClient(parts[parts.length - 2], parts[parts.length - 1]);
     }
 }
 


### PR DESCRIPTION
This PR adds the `ClientUtil#webhook` function which will parse a webhook URL and return a [`WebhookClient`](https://discord.js.org/#/docs/main/master/class/WebhookClient).