### PR TITLE
Support ColorResolvable via "color" ArgumentType.

### DIFF
--- a/src/struct/commands/arguments/TypeResolver.js
+++ b/src/struct/commands/arguments/TypeResolver.js
@@ -1,5 +1,5 @@
 const { ArgumentTypes } = require('../../../util/Constants');
-const { Collection } = require('discord.js');
+const { Collection, resolveColor } = require('discord.js');
 const { URL } = require('url');
 
 /**
@@ -113,13 +113,8 @@ class TypeResolver {
 
             [ArgumentTypes.COLOR]: (message, phrase) => {
                 if (!phrase) return null;
-
-                const color = parseInt(phrase.replace('#', ''), 16);
-                if (color < 0 || color > 0xFFFFFF || isNaN(color)) {
-                    return null;
-                }
-
-                return color;
+                const color = phrase.startsWith('[') ? phrase.slice(phrase.indexOf('[') + 1).slice(0, phrase.indexOf(']') - 1).split(',').map(e => parseInt(e.trim())) : phrase.toUpperCase();
+                return resolveColor(color);
             },
 
             [ArgumentTypes.USER]: (message, phrase) => {


### PR DESCRIPTION
It's a little messy, so I welcome anyone to improve it, but this adjustment allows common names, hex values (with and without #), `'RANDOM'`, RGB array, and numbers to be used as values for the `'color'` `ArgumentType`.

Note that when using an RGB array, either the array must not have spaces in it, or `quoted: true` must be applied to the argument.

This method takes advantage of the `resolveColor()` method from `discord.js`. This theoretically means that anything that can be considered `ColorResolvable` should work. I've tested it with hex with and without #, RGB array with and without spaces/quotes, numbers, common names, and `RANDOM`, as listed [here ](https://discord.js.org/#/docs/main/master/typedef/ColorResolvable) in the Discord.js documentation.

This method also will not break the existing method which is to simply use a hex code as the value of an argument with `type: 'color'`.