### PR TITLE
fix(CommandUtil): check for the response to be deleted before trying to edit

### DIFF
--- a/src/struct/commands/CommandUtil.js
+++ b/src/struct/commands/CommandUtil.js
@@ -103,7 +103,7 @@ class CommandUtil {
         const hasFiles = (transformedOptions.files && transformedOptions.files.length > 0)
             || (transformedOptions.embed && transformedOptions.embed.files && transformedOptions.embed.files.length > 0);
 
-        if (this.shouldEdit && (this.command ? this.command.editable : true) && !hasFiles && !this.lastResponse.attachments.size) {
+        if (this.shouldEdit && (this.command ? this.command.editable : true) && !hasFiles && !this.lastResponse.deleted && !this.lastResponse.attachments.size) {
             return this.lastResponse.edit(transformedOptions);
         }
 


### PR DESCRIPTION
Steps to reproduce:
1) let bot respond to a command, having editable + command util enabled
2) delete bot response
3) edit the message with another response

expected: bot sends a new message
actual: DiscordAPI error because the deleted message can not be edited

This PR attempts to solve this by checking for a deletion before letting the CommandUtil edit the response

The message being sent as a new message instead seems to be the intended and most expected result in this case (as that's imo the entire point behind cmdutil, to handle edits dynamically, and instead send if not possible to edit), should you disagree let me know.