### PR TITLE
replace non-standard quotation marks fixes #79

### DIFF
--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -222,6 +222,7 @@ class CommandHandler extends AkairoHandler {
         this.client.once('ready', () => {
             this.client.on('message', async m => {
                 if (m.partial) await m.fetch();
+                m.content.replace(/(?<!\\)[“”]/g, '"');
                 this.handle(m);
             });
 


### PR DESCRIPTION
I added a regular expression that replaces non-escaped opening and closing quotation marks (” and “) with regular quotation marks (").