### PR TITLE
perf(Util): prefer `Array.prototype.flatMap` when present

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -40,6 +40,10 @@ class Util {
     }
 
     static flatMap(xs, f) {
+        if (Array.prototype.flatMap) {
+            return xs.flatMap(i => f(i));
+        }
+        
         const res = [];
         for (const x of xs) {
             res.push(...f(x));


### PR DESCRIPTION
[`Array.prototype.flatMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) is faster than the custom implementation, but only available in Node.js 11+.
This prefers the native function when it's present, and if not falls back to the custom version, preserving compatibility with older versions of Node.js.