### PR TITLE
feat: support promises in command conditions

### DIFF
--- a/test/commands/condition.js
+++ b/test/commands/condition.js
@@ -1,0 +1,17 @@
+const { Command } = require('../../src');
+
+class ConditionalCommand extends Command {
+    constructor() {
+        super('condition');
+    }
+
+    condition(message) {
+        return message.content === 'make me condition';
+    }
+
+    exec(message) {
+        return message.util.reply('made you condition');
+    }
+}
+
+module.exports = ConditionalCommand;

--- a/test/commands/condition.promise.js
+++ b/test/commands/condition.promise.js
@@ -1,0 +1,17 @@
+const { Command } = require('../../src');
+
+class ConditionalPromiseCommand extends Command {
+    constructor() {
+        super('condition.promise');
+    }
+
+    condition(message) {
+        return Promise.resolve(message.content === 'make me promise condition');
+    }
+
+    exec(message) {
+        return message.util.reply('made you promise condition');
+    }
+}
+
+module.exports = ConditionalPromiseCommand;


### PR DESCRIPTION
Currently if a command's `condition` returns a promise, it would always run the command as it does not resolve the promise.
This PR fixes that by checking for the promise and resolving it if applicable.

*This does not break `handleConditionalCommands`, it already returns a Promise.*

Additionally, I've added tests or both normal and promise conditional commands.