### PR TITLE
Enhance Arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,6 @@
         "commands",
         "arguments"
     ],
-    "dependencies": {
-        "discord.js": "^12.2.0",
-        "mongoose": "^5.9.22",
-        "sequelize": "^6.3.0",
-        "sqlite": "^4.0.11"
-    },
     "peerDependencies": {
         "discord.js": "^12.0.0",
         "sqlite": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,12 @@
         "commands",
         "arguments"
     ],
-    "dependencies": {},
+    "dependencies": {
+        "discord.js": "^12.2.0",
+        "mongoose": "^5.9.22",
+        "sequelize": "^6.3.0",
+        "sqlite": "^4.0.11"
+    },
     "peerDependencies": {
         "discord.js": "^12.0.0",
         "sqlite": "^3.0.3",
@@ -31,7 +36,8 @@
         "jsdoc": "^3.6.4",
         "tslint": "^5.15.0",
         "tslint-config-typings": "^0.3.1",
-        "typescript": "^3.4.2"
+        "typescript": "^3.4.2",
+        "sqlite3": "^5.0.0"
     },
     "scripts": {
         "test": "npm run lint",

--- a/src/struct/commands/arguments/Argument.js
+++ b/src/struct/commands/arguments/Argument.js
@@ -590,9 +590,10 @@ class Argument {
                 entry = Argument.tagged(entry);
                 const res = await Argument.cast.call(this, entry, this.handler.resolver, message, phrase);
                 if (!Argument.isFailure(res)) return res;
+                lastFailure = res;
             }
 
-            return null;
+            return lastFailure;
         };
     }
     /* eslint-enable no-invalid-this */

--- a/src/struct/commands/arguments/TypeResolver.js
+++ b/src/struct/commands/arguments/TypeResolver.js
@@ -1,4 +1,5 @@
 const { ArgumentTypes } = require('../../../util/Constants');
+const Flag = require('../Flag');
 const { Collection } = require('discord.js');
 const { URL } = require('url');
 
@@ -48,6 +49,10 @@ class TypeResolver {
      */
     addBuiltInTypes() {
         const builtins = {
+            [ArgumentTypes.REQUIRED]: (message, phrase) => {
+                return phrase || Flag.fail({ reason: 'requiredFailed', input: phrase });
+            },
+
             [ArgumentTypes.STRING]: (message, phrase) => {
                 return phrase || null;
             },

--- a/src/struct/commands/arguments/TypeResolver.js
+++ b/src/struct/commands/arguments/TypeResolver.js
@@ -50,7 +50,7 @@ class TypeResolver {
     addBuiltInTypes() {
         const builtins = {
             [ArgumentTypes.REQUIRED]: (message, phrase) => {
-                return phrase || Flag.fail({ reason: 'requiredFailed', input: phrase });
+                return phrase || Flag.fail({ reason: 'requiredFailed' });
             },
 
             [ArgumentTypes.STRING]: (message, phrase) => {

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -11,6 +11,7 @@ module.exports = {
         NONE: 'none'
     },
     ArgumentTypes: {
+        REQUIRED: 'required',
         STRING: 'string',
         LOWERCASE: 'lowercase',
         UPPERCASE: 'uppercase',

--- a/test/commands/defaultflags.js
+++ b/test/commands/defaultflags.js
@@ -1,0 +1,65 @@
+const { Command, Argument, Flag } = require('../..');
+
+class DefaultFlagsCommand extends Command {
+    constructor() {
+        super('df', {
+            aliases: ['df'],
+            args: [
+                {
+                    // This arg is for testing Argument.validate's default flag
+                    id: 'n',
+                    type: Argument.validate('integer', (m, p, v) => v !== 5),
+                    otherwise: (msg, { failure }) => {
+                        // if the value is 5, this should return "validateFailed"
+                        if (failure) {
+                            return failure.value.reason;
+                        } else {
+                            return 'An error occurred while parsing arg `n`, is it missing?';
+                        }
+                    },
+                },
+                {
+                    // This arg is for testing Argument.range's default flag
+                    id: 'x',
+                    type: Argument.range('integer', 1, 4, true),
+                    otherwise: (msg, { failure }) => {
+                        // If the argument is out of range, this should return 'rangeFailed'
+                        return failure.value.reason;
+                    }
+                },
+                {
+                    // This arg is for testing Argument.union's handling of flags
+                    id: 'u',
+                    type: Argument.union( 
+                        Argument.validate('lowercase', (message, phrase, value) => value === 'one' || value === 'two'),
+                        async (message, phrase) => {
+                            const result = await Argument.range('integer', 1, 2, true).call(this, message, phrase);
+                            if (Argument.isFailure(result)) return Flag.fail({ reason: 'notOneOrTwo'});
+                            return phrase;
+                        }
+                    ),
+                    otherwise: (msg, { failure }) => {
+                        // In the case that the value is not either "no" or an integer between 1 and 4 (inclusive),
+                        // this should always return "b", as it is the last case that can fail
+                        return failure.value.reason;
+                    }
+                },
+                {
+                    // This arg is for testing the new 'required' default type's default flag
+                    id: 'r',
+                    type: 'required',
+                    otherwise: (msg, { failure }) => {
+                        // If this argument is not provided, this should return 'reequiredFailed'
+                        return failure.value.reason;
+                    }
+                }
+            ]
+        });
+    }
+
+    exec(message) {
+        return message.channel.send('success');
+    }
+}
+
+module.exports = DefaultFlagsCommand;

--- a/test/struct/TestClient.js
+++ b/test/struct/TestClient.js
@@ -1,5 +1,6 @@
 const { AkairoClient, CommandHandler, InhibitorHandler, ListenerHandler, SQLiteProvider } = require('../../src/index');
 const sqlite = require('sqlite');
+const sqlite3 = require('sqlite3');
 
 class TestClient extends AkairoClient {
     constructor() {
@@ -41,7 +42,7 @@ class TestClient extends AkairoClient {
             directory: './test/listeners/'
         });
 
-        const db = sqlite.open('./test/db.sqlite')
+        const db = sqlite.open({filename: './test/db.sqlite', driver: sqlite3.Database})
             .then(d => d.run('CREATE TABLE IF NOT EXISTS guilds (id TEXT NOT NULL UNIQUE, settings TEXT)').then(() => d));
         this.settings = new SQLiteProvider(db, 'guilds', { dataColumn: 'settings' });
 


### PR DESCRIPTION
While rewriting part of [FCFS](https://github.com/perilstar/fcfs-bot), I noticed that custom argument functions couldn't use Argument methods, throwing `TypeError: Cannot read property 'handler' of undefined`. As well as this, I realised that the default value returned from `Argument.validate`, `Argument.range`, etc is simply null when they fail, and this isn't very useful to a programmer trying to add custom error messages. I've patched in this functionality, using `.call`. This allows for the following type of code within commands:

```js
const { Command, Argument, Flag } = require('discord-akairo');

class FooCommand extends Command {
    constructor() {
        super('foo', {
            aliases: ['foo'],
            args: [
                {
                    id: 'u',
                    type: (message, phrase) => {
                        const result = Argument.range('integer', 2, 5, true).call(this, message, phrase);

                        // If this line isn't here to replace the flag returned by the range method, it'll be 'rangeFailed' when it fails instead.
                        // Note: if there's nothing supplied in the first place, it'll end up 'validateFailed' because Argument.range uses Argument.validate internally
                        if (Argument.isFailure(result)) return Flag.fail({reason: 'fooFailed'});
                        return result;
                    },
                    otherwise: (msg, { failure }) => {
                        return failure.value.reason;
                    }
                }
            ]
        });
    }

    exec(message) {
        return message.channel.send('bar');
    }
}

module.exports = FooCommand;
```

The new default flags have their `.value.reason` set to "\<method\>Failed" (eg. "rangeFailed"), and include other information about the thing that failed as other properties on `.value`.
I've also added a new default type, 'required' which returns `Flag.fail({ reason: 'requiredFailed' })` when no argument is provided.

This would need to be updated in the guide so people understand how to use it. 