### PR TITLE
fix: return a cancel flag if a user cancels a prompt

### DIFF
--- a/src/struct/commands/arguments/ArgumentRunner.js
+++ b/src/struct/commands/arguments/ArgumentRunner.js
@@ -184,7 +184,13 @@ class ArgumentRunner {
 
         const res = [];
         for (const phrase of phrases) {
-            res.push(await arg.process(message, phrase.value));
+            const response = await arg.process(message, phrase.value);
+
+            if (Flag.is(response, 'cancel')) {
+                return response;
+            }
+
+            res.push(response);
         }
 
         if (arg.index != null) {


### PR DESCRIPTION
### issue

When executing `Argument.runSeparate`, provided arguments are pushed into an array, but if a user provides an incorrect argument type and cancels the prompt, a cancel `Flag` is generated but it's pushed into the array. Since the `flag` is in an `Array`, `Argument.isShortCircuit` returns false and the command executes, even though the user cancelled.

### example

If the `args` array for a command is:

```javascript
// command aliases: numbers
[
  {
    id: 'amount',
    match: 'separate',
    type: 'number',
    prompt: { start: 'please provide a valid number.', retry: 'please provide a valid number to use.' },
  }
]
```

and you execute the command with:

```
!numbers not_a_number1 not_a_number2
```

As the arguments aren't numbers, the user will be prompted to provide a valid argument for each invalid argument. So they're prompted to provide a number for `not_a_number1`, and if they `cancel`, the client will respond with the cancel text, and then respond with the `retry` text to provide a valid argument for `not_a_number2`, and if the user enters `cancel` again, the command executes with the `args` object as:

```javascript
{ amount: [ Flag { type: 'cancel' }, Flag { type: 'cancel' } ] }
```

### solution

To fix this, `Argument.runSeparate` asks the user for a valid argument, and if the user cancels, the method returns the flag, otherwise, the response is pushed into the array.

This allows `Argument.isShortCircuit` to successfully determine if the given flag is a cancel flag.