### PR TITLE
refractor: support promises for ignorePermissions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -167,7 +167,7 @@ declare module 'discord-akairo' {
         public lock?: KeySupplier;
         public locker?: Set<string>;
         public ignoreCooldown?: Snowflake | Snowflake[] | IgnoreCheckPredicate;
-        public ignorePermissions?: Snowflake | Snowflake[] | IgnoreCheckPredicate;
+        public ignorePermissions?: Snowflake | Snowflake[] | IgnoreCheckPredicateWithPromise;
         public ownerOnly: boolean;
         public prefix?: string | string[] | PrefixSupplier;
         public ratelimit: number;
@@ -205,7 +205,7 @@ declare module 'discord-akairo' {
         public fetchMembers: boolean;
         public handleEdits: boolean;
         public ignoreCooldown: Snowflake | Snowflake[] | IgnoreCheckPredicate;
-        public ignorePermissions: Snowflake | Snowflake[] | IgnoreCheckPredicate;
+        public ignorePermissions: Snowflake | Snowflake[] | IgnoreCheckPredicateWithPromise;
         public inhibitorHandler?: InhibitorHandler;
         public modules: Collection<string, Command>;
         public prefix: string | string[] | PrefixSupplier;
@@ -557,7 +557,7 @@ declare module 'discord-akairo' {
         editable?: boolean;
         flags?: string[];
         ignoreCooldown?: Snowflake | Snowflake[] | IgnoreCheckPredicate;
-        ignorePermissions?: Snowflake | Snowflake[] | IgnoreCheckPredicate;
+        ignorePermissions?: Snowflake | Snowflake[] | IgnoreCheckPredicateWithPromise;
         lock?: KeySupplier | 'guild' | 'channel' | 'user';
         optionFlags?: string[];
         ownerOnly?: boolean;
@@ -583,7 +583,7 @@ declare module 'discord-akairo' {
         fetchMembers?: boolean;
         handleEdits?: boolean;
         ignoreCooldown?: Snowflake | Snowflake[] | IgnoreCheckPredicate;
-        ignorePermissions?: Snowflake | Snowflake[] | IgnoreCheckPredicate;
+        ignorePermissions?: Snowflake | Snowflake[] | IgnoreCheckPredicateWithPromise;
         prefix?: string | string[] | PrefixSupplier;
         storeMessages?: boolean;
     }
@@ -672,6 +672,8 @@ declare module 'discord-akairo' {
     export type ExecutionPredicate = (message: Message) => boolean;
 
     export type IgnoreCheckPredicate = (message: Message, command: Command) => boolean;
+
+    export type IgnoreCheckPredicateWithPromise = (message: Message, command: Command) => boolean | Promise<boolean>;
 
     export type KeySupplier = (message: Message, args: any) => string;
 

--- a/src/struct/commands/Command.js
+++ b/src/struct/commands/Command.js
@@ -180,7 +180,7 @@ class Command extends AkairoModule {
 
         /**
          * ID of user(s) to ignore `userPermissions` checks or a function to ignore.
-         * @type {?Snowflake|Snowflake[]|IgnoreCheckPredicate}
+         * @type {?Snowflake|Snowflake[]|IgnoreCheckPredicateWithPromise}
          */
         this.ignorePermissions = typeof ignorePermissions === 'function' ? ignorePermissions.bind(this) : ignorePermissions;
 
@@ -261,7 +261,7 @@ module.exports = Command;
  * @prop {BeforeAction} [before] - Function to run before argument parsing and execution.
  * @prop {KeySupplier|string} [lock] - The key type or key generator for the locker. If lock is a string, it's expected one of 'guild', 'channel', or 'user'.
  * @prop {Snowflake|Snowflake[]|IgnoreCheckPredicate} [ignoreCooldown] - ID of user(s) to ignore cooldown or a function to ignore.
- * @prop {Snowflake|Snowflake[]|IgnoreCheckPredicate} [ignorePermissions] - ID of user(s) to ignore `userPermissions` checks or a function to ignore.
+ * @prop {Snowflake|Snowflake[]|IgnoreCheckPredicateWithPromise} [ignorePermissions] - ID of user(s) to ignore `userPermissions` checks or a function to ignore.
  * @prop {DefaultArgumentOptions} [argumentDefaults] - The default argument options.
  * @prop {StringResolvable} [description=''] - Description of the command.
  */

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -671,7 +671,7 @@ class CommandHandler extends AkairoHandler {
             const isIgnored = Array.isArray(ignorer)
                 ? ignorer.includes(message.author.id)
                 : typeof ignorer === 'function'
-                    ? ignorer(message, command)
+                    ? await ignorer(message, command)
                     : message.author.id === ignorer;
 
             if (!isIgnored) {

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -155,7 +155,7 @@ class CommandHandler extends AkairoHandler {
 
         /**
          * ID of user(s) to ignore `userPermissions` checks or a function to ignore.
-         * @type {Snowflake|Snowflake[]|IgnoreCheckPredicate}
+         * @type {Snowflake|Snowflake[]|IgnoreCheckPredicateWithPromise}
          */
         this.ignorePermissions = typeof ignorePermissions === 'function' ? ignorePermissions.bind(this) : ignorePermissions;
 
@@ -1149,7 +1149,7 @@ module.exports = CommandHandler;
  * @prop {number} [defaultCooldown=0] - The default cooldown for commands.
  * @prop {Snowflake|Snowflake[]|IgnoreCheckPredicate} [ignoreCooldown] - ID of user(s) to ignore cooldown or a function to ignore.
  * Defaults to the client owner(s).
- * @prop {Snowflake|Snowflake[]|IgnoreCheckPredicate} [ignorePermissions=[]] - ID of user(s) to ignore `userPermissions` checks or a function to ignore.
+ * @prop {Snowflake|Snowflake[]|IgnoreCheckPredicateWithPromise} [ignorePermissions=[]] - ID of user(s) to ignore `userPermissions` checks or a function to ignore.
  * @prop {DefaultArgumentOptions} [argumentDefaults] - The default argument options.
  */
 
@@ -1173,6 +1173,16 @@ module.exports = CommandHandler;
 
 /**
  * A function that returns whether this message should be ignored for a certain check.
+ * <info>This also supports promise returns unlike {@link IgnoreCheckPredicate}</info>
+ * @typedef {Function} IgnoreCheckPredicateWithPromise
+ * @param {Message} message - Message to check.
+ * @param {Command} command - Command to check.
+ * @returns {boolean|Promise<boolean>}
+ */
+
+/**
+ * A function that returns whether this message should be ignored for a certain check.
+ * <warn>This **does not** support promise returns unlike {@link IgnoreCheckPredicateWithPromise}</warn>
  * @typedef {Function} IgnoreCheckPredicate
  * @param {Message} message - Message to check.
  * @param {Command} command - Command to check.


### PR DESCRIPTION
## Changes
 - Add a typedef for `IgnoreCheckPredicate` with promise support (named `IgnoreCheckPredicateWithPromise`)
 - Support for promises in `runPermissionChecks`
## Notes
 - Promises can't be supported in cooldown checks as runCooldowns is synchronous
 - Resolves #155 