### PR TITLE
fix(docs): Fix function parameters in modifyPrompt

### DIFF
--- a/docs/arguments/prompts.md
+++ b/docs/arguments/prompts.md
@@ -174,8 +174,8 @@ It is most useful inside the `argumentDefaults` option, such as on the command h
 ```js
 argumentDefaults: {
     prompt: {
-        modifyStart: text => `${text}\nType cancel to cancel this command.`,
-        modifyRetry: text => `${text}\nType cancel to cancel this command.`,
+        modifyStart: (message, text) => `${text}\nType cancel to cancel this command.`,
+        modifyRetry: (message, text) => `${text}\nType cancel to cancel this command.`,
         timeout: 'Time ran out, command has been cancelled.',
         ended: 'Too many retries, command has been cancelled.',
         cancel: 'Command has been cancelled.',


### PR DESCRIPTION
In the prompts documentation, the example of "modifyStart" and "modifyRetry" was incorrect, as the first parameter it used was the text, where it is, in reality, the message.