### PR TITLE
Remove unnecessary second CommandHandler prefix function call

### DIFF
--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -780,8 +780,8 @@ class CommandHandler extends AkairoHandler {
      * @returns {Promise<ParsedComponentData>}
      */
     async parseCommand(message) {
-        let prefixes = intoArray(await intoCallable(this.prefix)(message));
         const allowMention = await intoCallable(this.prefix)(message);
+        let prefixes = intoArray(allowMention);
         if (allowMention) {
             const mentions = [`<@${this.client.user.id}>`, `<@!${this.client.user.id}>`];
             prefixes = [...mentions, ...prefixes];


### PR DESCRIPTION
Not a massive issue by any means but still somewhat annoying imo.
Just removes a second identical function call directly after the first when getting the prefix in the CommandHandler - suppose it's also an ever-so-slight performance improvement depending on how crazy your prefix-getting is? 