### PR TITLE
feat: named exports for esm users

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
         "commands",
         "arguments"
     ],
-    "dependencies": {},
+    "exports": {
+        "import": "./src/index.mjs",
+        "require": "./src/index.js"
+    },
     "devDependencies": {
         "@types/node": "^10.14.4",
         "discord.js-docgen": "github:discordjs/docgen",

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,0 +1,35 @@
+import Akairo from './index.js';
+
+export default Akairo;
+
+export const {
+    AkairoClient,
+    AkairoHandler,
+    AkairoModule,
+    ClientUtil,
+
+    Command,
+    CommandHandler,
+    CommandUtil,
+    Flag,
+
+    Argument,
+    TypeResolver,
+
+    Inhibitor,
+    InhibitorHandler,
+
+    Listener,
+    ListenerHandler,
+
+    Provider,
+    SequelizeProvider,
+    SQLiteProvider,
+    MongooseProvider,
+
+    AkairoError,
+    Category,
+    Constants,
+    Util,
+    version
+} = Akairo;


### PR DESCRIPTION
Adds an `index.mjs` file to the library so that you can import structures with ESM syntax.

Before, this resulted in the following:
```
import { CommandHandler } from 'discord-akairo';
         ^^^^^^^^^^^^^^
SyntaxError: Named export 'CommandHandler' not found. The requested module 'discord-akairo'
is a CommonJS module, which may not support all module.exports as named exports.
```

Resolves #122.