### PR TITLE
fix(typings): Made 3 improvements

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -78,6 +78,7 @@ declare module 'discord-akairo' {
 
         public reload(): this;
         public remove(): this;
+        public toString(): string;
     }
 
     export class Argument {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,6 +18,15 @@ declare module 'discord-akairo' {
     }
 
     export class AkairoError extends Error {
+        public constructor(key: 'ALIAS_CONFLICT', alias: string, id: string, conflict: string);
+        public constructor(key: 'ALREADY_LOADED' | 'MODULE_NOT_FOUND' | 'NOT_RELOADABLE', constructor: string, id: string);
+        public constructor(key: 'COMMAND_UTIL_EXPLICIT');
+        public constructor(key: 'FILE_NOT_FOUND', filename: string);
+        public constructor(key: 'INVALID_CLASS_TO_HANDLE', given: string, expected: string);
+        public constructor(key: 'INVALID_TYPE', name: string, expected: string, vowel?: boolean);
+        public constructor(key: 'NOT_INSTANTIABLE', constructor: string);
+        public constructor(key: 'NOT_IMPLEMENTED', constructor: string, method: string);
+        public constructor(key: 'UNKNOWN_MATCH_TYPE', match: string);
         public code: string;
     }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,7 +4,7 @@ declare module 'discord-akairo' {
         Message, MessageAttachment, MessageEmbed,
         MessageAdditions, MessageEditOptions, MessageOptions, SplitOptions,
         User, UserResolvable, GuildMember,
-        Channel, Role, Emoji, Guild,
+        Channel, TextChannel, NewsChannel, Role, Emoji, Guild,
         PermissionResolvable, StringResolvable, Snowflake
     } from 'discord.js';
 
@@ -187,6 +187,7 @@ declare module 'discord-akairo' {
 
         public before(message: Message): any;
         public condition(message: Message): boolean;
+        public exec(message: { channel: TextChannel | NewsChannel } & Message, args: any): any;
         public exec(message: Message, args: any): any;
         public parse(message: Message, content: string): Promise<Flag | any>;
         public reload(): this;


### PR DESCRIPTION
I made these improvements in a separated PR from #76 because I feel like this will be easier to review and merge, and hopefully will be published soon.

Here are the 3 changes I made, in 3 separate commits:
- Add all possible constructors to the `AkairoError` class. Previously, when using it, TypeScript would output an error because we are giving it X arguments, but only 1 was expected. This fixes this issue.
- `AkairoModule` has a `toString()` method, but it was not present in the typings. Although this might feel extraneous, it is quite important to specify it there because it can be useful for ESLint rules such as [`@typescript-eslint/no-base-to-string`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-base-to-string.md)
- Finally, I added an overload to `Command#exec()` where the message is from a text channel that is in a guild. This overload can be used when the `channel: 'guild'` option is passed in the command options. It will prevent typescript to give errors if we use guild-specific text channel methods (i.e. permission or position-related property/methods)

For devs that need theses changes, for the time being, you can use .d.ts files with `declare module 'discord-akairo' {}` and then overwrite the existing interfaces for the last two changes. For the first tho, if you don't want to create a new class, you can use the [`patch-package`](https://www.npmjs.com/package/patch-package) package, which I've been using and works great :)