### PR TITLE
Fixed outdated function references in ClientUtil

### DIFF
--- a/src/struct/ClientUtil.js
+++ b/src/struct/ClientUtil.js
@@ -360,7 +360,7 @@ class ClientUtil {
     }
 
     /**
-     * Combination of `<Client>.fetchUser()` and `<Guild>.fetchMember()`.
+     * Combination of `<Client>.users.fetch()` and `<Guild>.members.fetch()`.
      * @param {Guild} guild - Guild to fetch in.
      * @param {string} id - ID of the user.
      * @param {boolean} cache - Whether or not to add to cache.


### PR DESCRIPTION
Client#fetchUser and Guild#fetchMember were removed in v11 and replaced with UserManager#fetch and GuildMemberManager#fetch respectfully (https://discordjs.guide/additional-info/changes-in-v12.html#fetch)