### PR TITLE
fix: don't call the retry prompt if a command has a default value

### DIFF
--- a/src/struct/commands/arguments/Argument.js
+++ b/src/struct/commands/arguments/Argument.js
@@ -120,7 +120,7 @@ class Argument {
         const commandDefs = this.command.argumentDefaults;
         const handlerDefs = this.handler.argumentDefaults;
         const optional = choice(
-            this.prompt && this.prompt.optional,
+            !!this.default ?? (this.prompt && this.prompt.optional),
             commandDefs.prompt && commandDefs.prompt.optional,
             handlerDefs.prompt && handlerDefs.prompt.optional
         );


### PR DESCRIPTION
### issue

when executing `Argument.process`, `choice` is called to determine if the command has optional arguments or not. the problem being in the first parameter, `this.prompt && this.prompt.optional`, determines if a `optional` value is set within a command's args object, however it doesn't check if a default value is set.

so, if a command is ran with a default value, a retry prompt is still executed as the first parameter doesn't check if a default value is set for the argument.

### example

if we have a command with args set as
```TypeScript
// alias: greet
args: [
  {
    id: 'member',
    type: 'member',
    prompt: { retry: 'please provide a valid member.' },
    default: (message: Message) => message.member,
  },
],
```
and the command is run as `.greet`, a retry prompt is called even though the command has a default value set.

### solution

the solution is rather simple, just check if the command has a default value before checking if the `optional` property is set within the command's prompt.