### PR TITLE
Fix: Commandhandler actually checks if message has been edited

### DIFF
--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -403,7 +403,7 @@ class CommandHandler extends AkairoHandler {
         let key;
         try {
             if (!ignore) {
-                if (message.edited && !command.editable) return false;
+                if (message.editedTimestamp && !command.editable) return false;
                 if (await this.runPostTypeInhibitors(message, command)) return false;
             }
 
@@ -464,7 +464,7 @@ class CommandHandler extends AkairoHandler {
     async handleRegexCommands(message) {
         const hasRegexCommands = [];
         for (const command of this.modules.values()) {
-            if (message.edited ? command.editable : true) {
+            if (message.editedTimestamp ? command.editable : true) {
                 const regex = typeof command.regex === 'function' ? command.regex(message) : command.regex;
                 if (regex) hasRegexCommands.push({ command, regex });
             }
@@ -520,7 +520,7 @@ class CommandHandler extends AkairoHandler {
 
         const filterPromises = [];
         for (const command of this.modules.values()) {
-            if (message.edited && !command.editable) continue;
+            if (message.editedTimestamp && !command.editable) continue;
             filterPromises.push((async () => {
                 let cond = command.condition(message);
                 if (isPromise(cond)) cond = await cond;


### PR DESCRIPTION
* Issue

When you have 'handleEdits: true' in commandHandler, and you set some commands to have 'editable: false', these commands will still execute when messages are edited.

* Solution
Actually use the correct message property to check if its been edited.