### PR TITLE
Update docs for CommandHandler messageInvalid event

### DIFF
--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -1036,7 +1036,7 @@ module.exports = CommandHandler;
  */
 
 /**
- * Emitted when no command has ben run.
+ * Emitted when no command has been run.
  * @event CommandHandler#messageInvalid
  * @param {Message} message - Message sent.
  */

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -1036,7 +1036,7 @@ module.exports = CommandHandler;
  */
 
 /**
- * Emitted when a message does not start with the prefix or match a command.
+ * Emitted when no command has ben run.
  * @event CommandHandler#messageInvalid
  * @param {Message} message - Message sent.
  */


### PR DESCRIPTION
Correct docs as the event will be emitted even if a command has been found but blocked, for example by setting `channel: 'guild'` in the CommandOptions.

https://github.com/discord-akairo/discord-akairo/blob/29810b9e5d5cd804c649948ad60e5f2ac3897141/src/struct/commands/CommandHandler.js#L382


**I would highly recommend restructuring the logic to provide the behaivour that is currently advertised in the doc  instead of merging this**