### PR TITLE
fix: remove references to StringResolvable

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,7 +5,7 @@ declare module 'discord-akairo' {
         MessageAdditions, MessageEditOptions, MessageOptions, SplitOptions,
         User, UserResolvable, GuildMember,
         Channel, Role, Emoji, Guild,
-        PermissionResolvable, StringResolvable, Snowflake
+        PermissionResolvable, Snowflake
     } from 'discord.js';
 
     import { EventEmitter } from 'events';
@@ -84,7 +84,7 @@ declare module 'discord-akairo' {
         public match: ArgumentMatch;
         public multipleFlags: boolean;
         public flag?: string | string[];
-        public otherwise?: StringResolvable | MessageOptions | MessageAdditions | OtherwiseContentSupplier;
+        public otherwise?: string | MessageOptions | MessageAdditions | OtherwiseContentSupplier;
         public prompt?: ArgumentPromptOptions | boolean;
         public type: ArgumentType | ArgumentTypeCaster;
         public unordered: boolean | number | number[];
@@ -272,30 +272,30 @@ declare module 'discord-akairo' {
         public shouldEdit: boolean;
 
         public addMessage(message: Message | Message[]): Message | Message[];
-        public edit(content?: StringResolvable, options?: MessageEmbed | MessageEditOptions): Promise<Message>;
+        public edit(content?: string, options?: MessageEmbed | MessageEditOptions): Promise<Message>;
         public edit(options?: MessageOptions | MessageAdditions): Promise<Message>;
-        public reply(content?: StringResolvable, options?: MessageOptions | MessageAdditions): Promise<Message>;
-        public reply(content?: StringResolvable, options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
-        public reply(content?: StringResolvable, options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
+        public reply(content?: string, options?: MessageOptions | MessageAdditions): Promise<Message>;
+        public reply(content?: string, options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
+        public reply(content?: string, options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
         public reply(options?: MessageOptions | MessageAdditions): Promise<Message>;
         public reply(options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
         public reply(options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
-        public send(content?: StringResolvable, options?: MessageOptions | MessageAdditions): Promise<Message>;
-        public send(content?: StringResolvable, options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
-        public send(content?: StringResolvable, options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
+        public send(content?: string, options?: MessageOptions | MessageAdditions): Promise<Message>;
+        public send(content?: string, options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
+        public send(content?: string, options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
         public send(options?: MessageOptions | MessageAdditions): Promise<Message>;
         public send(options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
         public send(options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
-        public sendNew(content?: StringResolvable, options?: MessageOptions | MessageAdditions): Promise<Message>;
-        public sendNew(content?: StringResolvable, options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
-        public sendNew(content?: StringResolvable, options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
+        public sendNew(content?: string, options?: MessageOptions | MessageAdditions): Promise<Message>;
+        public sendNew(content?: string, options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
+        public sendNew(content?: string, options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
         public sendNew(options?: MessageOptions | MessageAdditions): Promise<Message>;
         public sendNew(options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
         public sendNew(options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
         public setEditable(state: boolean): this;
         public setLastResponse(message: Message | Message[]): Message;
 
-        public static transformOptions(content?: StringResolvable, options?: MessageOptions | MessageAdditions): any[];
+        public static transformOptions(content?: string, options?: MessageOptions | MessageAdditions): any[];
     }
 
     export class Flag {
@@ -489,13 +489,13 @@ declare module 'discord-akairo' {
 
     export interface DefaultArgumentOptions {
         prompt?: ArgumentPromptOptions;
-        otherwise?: StringResolvable | MessageOptions | MessageAdditions | OtherwiseContentSupplier;
+        otherwise?: string | MessageOptions | MessageAdditions | OtherwiseContentSupplier;
         modifyOtherwise?: OtherwiseContentModifier;
     }
 
     export interface ArgumentOptions {
         default?: DefaultValueSupplier | any;
-        description?: StringResolvable;
+        description?: string;
         id?: string;
         index?: number;
         limit?: number;
@@ -503,7 +503,7 @@ declare module 'discord-akairo' {
         modifyOtherwise?: OtherwiseContentModifier;
         multipleFlags?: boolean;
         flag?: string | string[];
-        otherwise?: StringResolvable | MessageOptions | MessageAdditions | OtherwiseContentSupplier;
+        otherwise?: string | MessageOptions | MessageAdditions | OtherwiseContentSupplier;
         prompt?: ArgumentPromptOptions | boolean;
         type?: ArgumentType | ArgumentTypeCaster;
         unordered?: boolean | number | number[];
@@ -519,9 +519,9 @@ declare module 'discord-akairo' {
 
     export interface ArgumentPromptOptions {
         breakout?: boolean;
-        cancel?: StringResolvable | MessageOptions | MessageAdditions | PromptContentSupplier;
+        cancel?: string | MessageOptions | MessageAdditions | PromptContentSupplier;
         cancelWord?: string;
-        ended?: StringResolvable | MessageOptions | MessageAdditions | PromptContentSupplier;
+        ended?: string | MessageOptions | MessageAdditions | PromptContentSupplier;
         infinite?: boolean;
         limit?: number;
         modifyCancel?: PromptContentModifier;
@@ -531,11 +531,11 @@ declare module 'discord-akairo' {
         modifyTimeout?: PromptContentModifier;
         optional?: boolean;
         retries?: number;
-        retry?: StringResolvable | MessageOptions | MessageAdditions | PromptContentSupplier;
-        start?: StringResolvable | MessageOptions | MessageAdditions | PromptContentSupplier;
+        retry?: string | MessageOptions | MessageAdditions | PromptContentSupplier;
+        start?: string | MessageOptions | MessageAdditions | PromptContentSupplier;
         stopWord?: string;
         time?: number;
-        timeout?: StringResolvable | MessageOptions | MessageAdditions | PromptContentSupplier;
+        timeout?: string | MessageOptions | MessageAdditions | PromptContentSupplier;
     }
 
     export interface ArgumentRunnerState {
@@ -553,7 +553,7 @@ declare module 'discord-akairo' {
         clientPermissions?: PermissionResolvable | PermissionResolvable[] | MissingPermissionSupplier;
         condition?: ExecutionPredicate;
         cooldown?: number;
-        description?: StringResolvable;
+        description?: string;
         editable?: boolean;
         flags?: string[];
         ignoreCooldown?: Snowflake | Snowflake[] | IgnoreCheckPredicate;
@@ -682,20 +682,20 @@ declare module 'discord-akairo' {
     export type MissingPermissionSupplier = (message: Message) => Promise<any> | any;
 
     export type OtherwiseContentModifier = (message: Message, text: string, data: FailureData)
-        => StringResolvable | MessageOptions | MessageAdditions | Promise<StringResolvable | MessageOptions | MessageAdditions>;
+        => string | MessageOptions | MessageAdditions | Promise<string | MessageOptions | MessageAdditions>;
 
     export type OtherwiseContentSupplier = (message: Message, data: FailureData)
-        => StringResolvable | MessageOptions | MessageAdditions | Promise<StringResolvable | MessageOptions | MessageAdditions>;
+        => string | MessageOptions | MessageAdditions | Promise<string | MessageOptions | MessageAdditions>;
 
     export type ParsedValuePredicate = (message: Message, phrase: string, value: any) => boolean;
 
     export type PrefixSupplier = (message: Message) => string | string[] | Promise<string | string[]>;
 
     export type PromptContentModifier = (message: Message, text: string, data: ArgumentPromptData)
-        => StringResolvable | MessageOptions | MessageAdditions | Promise<StringResolvable | MessageOptions | MessageAdditions>;
+        => string | MessageOptions | MessageAdditions | Promise<string | MessageOptions | MessageAdditions>;
 
     export type PromptContentSupplier = (message: Message, data: ArgumentPromptData)
-        => StringResolvable | MessageOptions | MessageAdditions | Promise<StringResolvable | MessageOptions | MessageAdditions>;
+        => string | MessageOptions | MessageAdditions | Promise<string | MessageOptions | MessageAdditions>;
 
     export type RegexSupplier = (message: Message) => RegExp;
 

--- a/src/struct/commands/Command.js
+++ b/src/struct/commands/Command.js
@@ -263,7 +263,7 @@ module.exports = Command;
  * @prop {Snowflake|Snowflake[]|IgnoreCheckPredicate} [ignoreCooldown] - ID of user(s) to ignore cooldown or a function to ignore.
  * @prop {Snowflake|Snowflake[]|IgnoreCheckPredicate} [ignorePermissions] - ID of user(s) to ignore `userPermissions` checks or a function to ignore.
  * @prop {DefaultArgumentOptions} [argumentDefaults] - The default argument options.
- * @prop {StringResolvable} [description=''] - Description of the command.
+ * @prop {string} [description=''] - Description of the command.
  */
 
 /**

--- a/src/struct/commands/CommandUtil.js
+++ b/src/struct/commands/CommandUtil.js
@@ -94,7 +94,7 @@ class CommandUtil {
 
     /**
      * Sends a response or edits an old response if available.
-     * @param {StringResolvable} [content=''] - Content to send.
+     * @param {string} [content=''] - Content to send.
      * @param {MessageOptions|MessageAdditions} [options={}] - Options to use.
      * @returns {Promise<Message|Message[]>}
      */
@@ -115,7 +115,7 @@ class CommandUtil {
 
     /**
      * Sends a response, overwriting the last response.
-     * @param {StringResolvable} [content=''] - Content to send.
+     * @param {string} [content=''] - Content to send.
      * @param {MessageOptions|MessageAdditions} [options={}] - Options to use.
      * @returns {Promise<Message|Message[]>}
      */
@@ -128,7 +128,7 @@ class CommandUtil {
 
     /**
      * Sends a response with a mention concantenated to it.
-     * @param {StringResolvable} [content=''] - Content to send.
+     * @param {string} [content=''] - Content to send.
      * @param {MessageOptions|MessageAdditions} [options={}] - Options to use.
      * @returns {Promise<Message|Message[]>}
      */
@@ -138,7 +138,7 @@ class CommandUtil {
 
     /**
      * Edits the last response.
-     * @param {StringResolvable} [content=''] - Content to send.
+     * @param {string} [content=''] - Content to send.
      * @param {MessageEditOptions|MessageEmbed} [options={}] - Options to use.
      * @returns {Promise<Message>}
      */
@@ -148,7 +148,7 @@ class CommandUtil {
 
     /**
      * Transform options for sending.
-     * @param {StringResolvable} [content=''] - Content to send.
+     * @param {string} [content=''] - Content to send.
      * @param {MessageOptions|MessageAdditions} [options={}] - Options to use.
      * @param {MessageOptions} [extra={}] - Extra options to add.
      * @returns {MessageOptions}

--- a/src/struct/commands/arguments/Argument.js
+++ b/src/struct/commands/arguments/Argument.js
@@ -83,7 +83,7 @@ class Argument {
 
         /**
          * The content or function supplying the content sent when argument parsing fails.
-         * @type {?StringResolvable|MessageOptions|MessageAdditions|OtherwiseContentSupplier}
+         * @type {?string|MessageOptions|MessageAdditions|OtherwiseContentSupplier}
          */
         this.otherwise = typeof otherwise === 'function' ? otherwise.bind(this) : otherwise;
 
@@ -629,7 +629,7 @@ module.exports = Argument;
  * Applicable to text, content, rest, or separate match only.
  * @prop {DefaultValueSupplier|any} [default=null] - Default value if no input or did not cast correctly.
  * If using a flag match, setting the default value to a non-void value inverses the result.
- * @prop {StringResolvable|MessageOptions|MessageAdditions|OtherwiseContentSupplier} [otherwise] - Text sent if argument parsing fails.
+ * @prop {string|MessageOptions|MessageAdditions|OtherwiseContentSupplier} [otherwise] - Text sent if argument parsing fails.
  * This overrides the `default` option and all prompt options.
  * @prop {OtherwiseContentModifier} [modifyOtherwise] - Function to modify otherwise content.
  * @prop {ArgumentPromptOptions} [prompt] - Prompt options for when user does not provide input.
@@ -660,11 +660,11 @@ module.exports = Argument;
  * @prop {number} [limit=Infinity] - Amount of inputs allowed for an infinite prompt before finishing.
  * @prop {boolean} [breakout=true] - Whenever an input matches the format of a command, this option controls whether or not to cancel this command and run that command.
  * The command to be run may be the same command or some other command.
- * @prop {StringResolvable|MessageOptions|MessageAdditions|PromptContentSupplier} [start] - Text sent on start of prompt.
- * @prop {StringResolvable|MessageOptions|MessageAdditions|PromptContentSupplier} [retry] - Text sent on a retry (failure to cast type).
- * @prop {StringResolvable|MessageOptions|MessageAdditions|PromptContentSupplier} [timeout] - Text sent on collector time out.
- * @prop {StringResolvable|MessageOptions|MessageAdditions|PromptContentSupplier} [ended] - Text sent on amount of tries reaching the max.
- * @prop {StringResolvable|MessageOptions|MessageAdditions|PromptContentSupplier} [cancel] - Text sent on cancellation of command.
+ * @prop {string|MessageOptions|MessageAdditions|PromptContentSupplier} [start] - Text sent on start of prompt.
+ * @prop {string|MessageOptions|MessageAdditions|PromptContentSupplier} [retry] - Text sent on a retry (failure to cast type).
+ * @prop {string|MessageOptions|MessageAdditions|PromptContentSupplier} [timeout] - Text sent on collector time out.
+ * @prop {string|MessageOptions|MessageAdditions|PromptContentSupplier} [ended] - Text sent on amount of tries reaching the max.
+ * @prop {string|MessageOptions|MessageAdditions|PromptContentSupplier} [cancel] - Text sent on cancellation of command.
  * @prop {PromptContentModifier} [modifyStart] - Function to modify start prompts.
  * @prop {PromptContentModifier} [modifyRetry] - Function to modify retry prompts.
  * @prop {PromptContentModifier} [modifyTimeout] - Function to modify timeout messages.
@@ -776,7 +776,7 @@ module.exports = Argument;
  * Defaults for argument options.
  * @typedef {Object} DefaultArgumentOptions
  * @prop {ArgumentPromptOptions} [prompt] - Default prompt options.
- * @prop {StringResolvable|MessageOptions|MessageAdditions|OtherwiseContentSupplier} [otherwise] - Default text sent if argument parsing fails.
+ * @prop {string|MessageOptions|MessageAdditions|OtherwiseContentSupplier} [otherwise] - Default text sent if argument parsing fails.
  * @prop {OtherwiseContentModifier} [modifyOtherwise] - Function to modify otherwise content.
  */
 
@@ -803,7 +803,7 @@ module.exports = Argument;
  * @param {Message} message - Message that triggered the command.
  * @param {string|MessageEmbed|MessageAttachment|MessageAttachment[]|MessageOptions} text - Text to modify.
  * @param {FailureData} data - Miscellaneous data.
- * @returns {StringResolvable|MessageOptions|MessageAdditions|Promise<StringResolvable|MessageOptions|MessageAdditions>}
+ * @returns {string|MessageOptions|MessageAdditions|Promise<string|MessageOptions|MessageAdditions>}
  */
 
 /**
@@ -811,7 +811,7 @@ module.exports = Argument;
  * @typedef {Function} OtherwiseContentSupplier
  * @param {Message} message - Message that triggered the command.
  * @param {FailureData} data - Miscellaneous data.
- * @returns {StringResolvable|MessageOptions|MessageAdditions|Promise<StringResolvable|MessageOptions|MessageAdditions>}
+ * @returns {string|MessageOptions|MessageAdditions|Promise<string|MessageOptions|MessageAdditions>}
  */
 
 /**
@@ -820,7 +820,7 @@ module.exports = Argument;
  * @param {Message} message - Message that triggered the command.
  * @param {string|MessageEmbed|MessageAttachment|MessageAttachment[]|MessageOptions} text - Text from the prompt to modify.
  * @param {ArgumentPromptData} data - Miscellaneous data.
- * @returns {StringResolvable|MessageOptions|MessageAdditions|Promise<StringResolvable|MessageOptions|MessageAdditions>}
+ * @returns {string|MessageOptions|MessageAdditions|Promise<string|MessageOptions|MessageAdditions>}
  */
 
 /**
@@ -828,5 +828,5 @@ module.exports = Argument;
  * @typedef {Function} PromptContentSupplier
  * @param {Message} message - Message that triggered the command.
  * @param {ArgumentPromptData} data - Miscellaneous data.
- * @returns {StringResolvable|MessageOptions|MessageAdditions|Promise<StringResolvable|MessageOptions|MessageAdditions>}
+ * @returns {string|MessageOptions|MessageAdditions|Promise<string|MessageOptions|MessageAdditions>}
  */


### PR DESCRIPTION
This replaces all references to `StringResolvable` with `string` due to https://github.com/discordjs/discord.js/pull/4880

`StringResolvable` no longer exists, and the base discord.js lib will now enforce strings.