### PR TITLE
fix(types): overload `AkairoClient` constructor

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,7 +22,8 @@ declare module 'discord-akairo' {
     }
 
     export class AkairoClient extends Client {
-        public constructor(options?: AkairoOptions & ClientOptions, clientOptions?: ClientOptions);
+        public constructor(options?: AkairoOptions & ClientOptions);
+        public constructor(options: AkairoOptions, clientOptions: ClientOptions);
 
         public ownerID: Snowflake | Snowflake[];
         public util: ClientUtil;


### PR DESCRIPTION
`AkairoClient`'s constructor accepts two overloads:

https://github.com/discord-akairo/discord-akairo/blob/3f00525d195f234331e5ddf15c742970d533fa3e/src/struct/AkairoClient.js#L12-L13

Which are:

- `AkairoOptions` as first argument, and d.js's `ClientOptions` as second.
- `AkairoOptions` and `ClientOptions` merged, when a second option is not passed.

The latter is achieved as `clientOptions` becomes `akairoOptions` when it's undefined.

| ℹ️ As a side note, those options will need to be revisited again when v13 releases, namely, removing `?:` from the first overload. |
| :---: |