### PR TITLE
fix(CommandUtil): update send/edit methods for Discord.js v13

### DIFF
--- a/docs/snippets/ping.md
+++ b/docs/snippets/ping.md
@@ -13,11 +13,11 @@ class PingCommand extends Command {
     async exec(message) {
         const sent = await message.util.reply('Pong!');
         const timeDiff = (sent.editedAt || sent.createdAt) - (message.editedAt || message.createdAt);
-        return message.util.reply([
-            'Pong!',
-            `🔂 **RTT**: ${timeDiff} ms`,
+        return message.util.reply(
+            'Pong!\n' +
+            `🔂 **RTT**: ${timeDiff} ms\n` +
             `💟 **Heartbeat**: ${Math.round(this.client.ws.ping)} ms`
-        ]);
+        );
     }
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -273,30 +273,12 @@ declare module 'discord-akairo' {
         public shouldEdit: boolean;
 
         public addMessage(message: Message | Message[]): Message | Message[];
-        public edit(content?: string, options?: MessageEmbed | MessageEditOptions): Promise<Message>;
-        public edit(options?: MessageOptions | MessageAdditions): Promise<Message>;
-        public reply(content?: string, options?: MessageOptions | MessageAdditions): Promise<Message>;
-        public reply(content?: string, options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
-        public reply(content?: string, options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
-        public reply(options?: MessageOptions | MessageAdditions): Promise<Message>;
-        public reply(options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
-        public reply(options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
-        public send(content?: string, options?: MessageOptions | MessageAdditions): Promise<Message>;
-        public send(content?: string, options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
-        public send(content?: string, options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
-        public send(options?: MessageOptions | MessageAdditions): Promise<Message>;
-        public send(options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
-        public send(options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
-        public sendNew(content?: string, options?: MessageOptions | MessageAdditions): Promise<Message>;
-        public sendNew(content?: string, options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
-        public sendNew(content?: string, options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
-        public sendNew(options?: MessageOptions | MessageAdditions): Promise<Message>;
-        public sendNew(options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
-        public sendNew(options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
+        public edit(options?: string | MessageEditOptions): Promise<Message>;
+        public reply(options?: string | MessageOptions): Promise<Message>;
+        public send(options?: string | MessageOptions): Promise<Message>;
+        public sendNew(options?: string | MessageOptions): Promise<Message>;
         public setEditable(state: boolean): this;
         public setLastResponse(message: Message | Message[]): Message;
-
-        public static transformOptions(content?: string, options?: MessageOptions | MessageAdditions): any[];
     }
 
     export class Flag {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -279,6 +279,8 @@ declare module 'discord-akairo' {
         public sendNew(options?: string | MessageOptions): Promise<Message>;
         public setEditable(state: boolean): this;
         public setLastResponse(message: Message | Message[]): Message;
+
+        public static transformOptions(options?: string | MessageOptions): MessageOptions;
     }
 
     export class Flag {

--- a/src/struct/commands/CommandUtil.js
+++ b/src/struct/commands/CommandUtil.js
@@ -151,7 +151,7 @@ class CommandUtil {
     static transformOptions(options) {
         if (typeof options === 'string') options = { content: options };
         if (!options.content) options.content = null;
-        if (!options.embeds) options.embeds = null;
+        if (!options.embeds) options.embeds = [];
         return options;
     }
 }

--- a/src/struct/commands/CommandUtil.js
+++ b/src/struct/commands/CommandUtil.js
@@ -149,7 +149,7 @@ class CommandUtil {
      * @returns {MessageOptions}
      */
     static transformOptions(options) {
-        const transformedOptions = typeof options === "string" ? { content: options } : { ...options };
+        const transformedOptions = typeof options === 'string' ? { content: options } : { ...options };
         if (!transformedOptions.content) transformedOptions.content = null;
         if (!transformedOptions.embeds) transformedOptions.embeds = [];
         return transformedOptions;

--- a/src/struct/commands/CommandUtil.js
+++ b/src/struct/commands/CommandUtil.js
@@ -1,4 +1,4 @@
-const { APIMessage, Collection } = require('discord.js');
+const { Collection } = require('discord.js');
 
 /**
  * Command utilities.

--- a/src/struct/commands/CommandUtil.js
+++ b/src/struct/commands/CommandUtil.js
@@ -149,10 +149,10 @@ class CommandUtil {
      * @returns {MessageOptions}
      */
     static transformOptions(options) {
-        if (typeof options === 'string') options = { content: options };
-        if (!options.content) options.content = null;
-        if (!options.embeds) options.embeds = [];
-        return options;
+        const transformedOptions = typeof options === "string" ? { content: options } : { ...options };
+        if (!transformedOptions.content) transformedOptions.content = null;
+        if (!transformedOptions.embeds) transformedOptions.embeds = [];
+        return transformedOptions;
     }
 }
 

--- a/src/struct/commands/CommandUtil.js
+++ b/src/struct/commands/CommandUtil.js
@@ -94,20 +94,17 @@ class CommandUtil {
 
     /**
      * Sends a response or edits an old response if available.
-     * @param {string} [content=''] - Content to send.
-     * @param {MessageOptions|MessageAdditions} [options={}] - Options to use.
+     * @param {string|MessageOptions} [options={}] - Options to use.
      * @returns {Promise<Message|Message[]>}
      */
-    async send(content, options) {
-        const transformedOptions = this.constructor.transformOptions(content, options);
-        const hasFiles = (transformedOptions.files && transformedOptions.files.length > 0)
-            || (transformedOptions.embed && transformedOptions.embed.files && transformedOptions.embed.files.length > 0);
+    async send(options) {
+        const hasFiles = options.files && options.files.length > 0;
 
         if (this.shouldEdit && (this.command ? this.command.editable : true) && !hasFiles && !this.lastResponse.deleted && !this.lastResponse.attachments.size) {
-            return this.lastResponse.edit(transformedOptions);
+            return this.lastResponse.edit(options);
         }
 
-        const sent = await this.message.channel.send(transformedOptions);
+        const sent = await this.message.channel.send(options);
         const lastSent = this.setLastResponse(sent);
         this.setEditable(!lastSent.attachments.size);
         return sent;
@@ -115,49 +112,35 @@ class CommandUtil {
 
     /**
      * Sends a response, overwriting the last response.
-     * @param {string} [content=''] - Content to send.
-     * @param {MessageOptions|MessageAdditions} [options={}] - Options to use.
+     * @param {string|MessageOptions} [options={}] - Options to use.
      * @returns {Promise<Message|Message[]>}
      */
     async sendNew(content, options) {
-        const sent = await this.message.channel.send(this.constructor.transformOptions(content, options));
+        const sent = await this.message.channel.send(options);
         const lastSent = this.setLastResponse(sent);
         this.setEditable(!lastSent.attachments.size);
         return sent;
     }
 
     /**
-     * Sends a response with a mention concantenated to it.
-     * @param {string} [content=''] - Content to send.
-     * @param {MessageOptions|MessageAdditions} [options={}] - Options to use.
+     * Sends a response replying to the user's message.
+     * @param {string|MessageOptions} [options={}] - Options to use.
      * @returns {Promise<Message|Message[]>}
      */
-    reply(content, options) {
-        return this.send(this.constructor.transformOptions(content, options, { reply: this.message.member || this.message.author }));
+    reply(options) {
+        return this.send({
+            reply: { messageReference: this.message, failIfNotExists: false },
+            ...(typeof options === "string" ? { content: options } : options)
+        });
     }
 
     /**
      * Edits the last response.
-     * @param {string} [content=''] - Content to send.
-     * @param {MessageEditOptions|MessageEmbed} [options={}] - Options to use.
+     * @param {string|MessageEditOptions} [options={}] - Options to use.
      * @returns {Promise<Message>}
      */
     edit(content, options) {
         return this.lastResponse.edit(content, options);
-    }
-
-    /**
-     * Transform options for sending.
-     * @param {string} [content=''] - Content to send.
-     * @param {MessageOptions|MessageAdditions} [options={}] - Options to use.
-     * @param {MessageOptions} [extra={}] - Extra options to add.
-     * @returns {MessageOptions}
-     */
-    static transformOptions(content, options, extra) {
-        const transformedOptions = APIMessage.transformOptions(content, options, extra);
-        if (!transformedOptions.content) transformedOptions.content = null;
-        if (!transformedOptions.embed) transformedOptions.embed = null;
-        return transformedOptions;
     }
 }
 


### PR DESCRIPTION
This fixes `CommandUtil` methods that send or edit a message to work with the upcoming Discord.js v13 release. It:
- Modifies `CommandUtil#reply` to use the new inline reply feature
- Modifies send/edit methods to take in only one `options` parameter which can be a string or a MessageOptions object
- Removes references to the removed `APIMessage#transformOptions`