### PR TITLE
fix: move awaitMessages filter to options

### DIFF
--- a/src/struct/commands/arguments/Argument.js
+++ b/src/struct/commands/arguments/Argument.js
@@ -270,7 +270,8 @@ class Argument {
 
             let input;
             try {
-                input = (await message.channel.awaitMessages(m => m.author.id === message.author.id, {
+                input = (await message.channel.awaitMessages({
+                    filter: m => m.author.id === message.author.id,
                     max: 1,
                     time: promptOptions.time,
                     errors: ['time']


### PR DESCRIPTION
Yet another v13 fix, this time for discordjs/discord.js#5903