### PR TITLE
fix: Usage of the `Id` syntax instead of the `ID` one

### DIFF
--- a/src/struct/AkairoClient.js
+++ b/src/struct/AkairoClient.js
@@ -33,7 +33,7 @@ class AkairoClient extends Client {
      * @returns {boolean}
      */
     isOwner(user) {
-        const id = this.users.resolveID(user);
+        const id = this.users.resolveId(user);
         return Array.isArray(this.ownerID)
             ? this.ownerID.includes(id)
             : id === this.ownerID;

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -339,7 +339,7 @@ class CommandHandler extends AkairoHandler {
      */
     async handle(message) {
         try {
-            if (this.fetchMembers && message.guild && !message.member && !message.webhookID) {
+            if (this.fetchMembers && message.guild && !message.member && !message.webhookId) {
                 await message.guild.members.fetch(message.author);
             }
 


### PR DESCRIPTION
**This pull request fix the new `Id` syntax of [this commit](https://github.com/discordjs/discord.js/commit/a7c6678c7246025c4b358a5396dbacf4a73148ee)**