### PR TITLE
Remove stopTyping

### DIFF
--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -871,7 +871,6 @@ class CommandHandler extends AkairoHandler {
      * @returns {void}
      */
     emitError(err, message, command) {
-        if (command && command.typing) message.channel.stopTyping();
         if (this.listenerCount(CommandHandlerEvents.ERROR)) {
             this.emit(CommandHandlerEvents.ERROR, err, message, command);
             return;


### PR DESCRIPTION
Fixes the issue reported in the support server: [message](https://discord.com/channels/305153029567676426/387777801412935691/869948841733025852)

> discord.js removed `stopTyping` in v13/master-branch