### PR TITLE
Bug fixes and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
 
 ## Installation
 
-Requires Node 12+ and Discord.js v12.  
+Requires Node 16+ and Discord.js v13.  
 
 *discord-akairo*  
 `npm install discord-akairo`

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
 
 ## Installation
 
-Requires Node 16+ and Discord.js v13.  
+Requires Node 16.6.0+ and Discord.js v13.  
 
 *discord-akairo*  
 `npm install discord-akairo`

--- a/src/struct/ClientUtil.js
+++ b/src/struct/ClientUtil.js
@@ -351,8 +351,8 @@ class ClientUtil {
      * @returns {number}
      */
     compareStreaming(oldMember, newMember) {
-        const s1 = oldMember.presence.activity && oldMember.presence.activity.type === 'STREAMING';
-        const s2 = newMember.presence.activity && newMember.presence.activity.type === 'STREAMING';
+        const s1 = oldMember.presence?.activities.find(c => c.type === "STREAMING");
+        const s2 = newMember.presence?.activities.find(c => c.type === "STREAMING");
         if (s1 === s2) return 0;
         if (s1) return 1;
         if (s2) return 2;

--- a/src/struct/ClientUtil.js
+++ b/src/struct/ClientUtil.js
@@ -351,8 +351,8 @@ class ClientUtil {
      * @returns {number}
      */
     compareStreaming(oldMember, newMember) {
-        const s1 = oldMember.presence?.activities.find(c => c.type === "STREAMING");
-        const s2 = newMember.presence?.activities.find(c => c.type === "STREAMING");
+        const s1 = oldMember.presence?.activities.find(c => c.type === 'STREAMING');
+        const s2 = newMember.presence?.activities.find(c => c.type === 'STREAMING');
         if (s1 === s2) return 0;
         if (s1) return 1;
         if (s2) return 2;

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -774,8 +774,8 @@ class CommandHandler extends AkairoHandler {
      * @returns {Promise<ParsedComponentData>}
      */
     async parseCommand(message) {
-        let prefixes = intoArray(await intoCallable(this.prefix)(message));
         const allowMention = await intoCallable(this.prefix)(message);
+        let prefixes = intoArray(allowMention);
         if (allowMention) {
             const mentions = [`<@${this.client.user.id}>`, `<@!${this.client.user.id}>`];
             prefixes = [...mentions, ...prefixes];

--- a/src/struct/commands/arguments/TypeResolver.js
+++ b/src/struct/commands/arguments/TypeResolver.js
@@ -327,7 +327,7 @@ class TypeResolver {
             [ArgumentTypes.GUILD_MESSAGE]: async (message, phrase) => {
                 if (!phrase) return null;
                 for (const channel of message.guild.channels.cache.values()) {
-                    if (channel.type !== 'GUILD_TEXT') continue;
+                    if (!channel.isText()) continue;
                     try {
                         return await channel.messages.fetch(phrase);
                     } catch (err) {
@@ -347,7 +347,7 @@ class TypeResolver {
 
                 if (message.guild) {
                     for (const channel of message.guild.channels.cache.values()) {
-                        if (channel.type !== 'GUILD_TEXT') continue;
+                        if (!channel.isText()) continue;
                         try {
                             return await channel.messages.fetch(phrase);
                         } catch (err) {


### PR DESCRIPTION
Readme: Changed the required nodejs and discord.js versions. 
ClientUtil: Fixed the `compareStreaming` function to work properly.
CommandHandler: Fixed `parseCommand` would call `intoCallable` twice
TypeResolver: Changed `GUILD_MESSAGE` and `RELEVANT_MESSAGE` to `isText`(supports text, threads and news channels) instead of `GUILD_TEXT`

> cc: @1Computer1 - since discord.js v13 is stable now, should discord-akairo be updated on npm aswell, if so I can go ahead and change the version number (9.0.0) 