### PR TITLE
fix: require options in client constructor

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,7 +22,7 @@ declare module 'discord-akairo' {
     }
 
     export class AkairoClient extends Client {
-        public constructor(options?: AkairoOptions & ClientOptions);
+        public constructor(options: AkairoOptions & ClientOptions);
         public constructor(options: AkairoOptions, clientOptions: ClientOptions);
 
         public ownerID: Snowflake | Snowflake[];

--- a/src/struct/AkairoClient.js
+++ b/src/struct/AkairoClient.js
@@ -4,12 +4,12 @@ const ClientUtil = require('./ClientUtil');
 /**
  * The Akairo framework client.
  * Creates the handlers and sets them up.
- * @param {AkairoOptions} [options={}] - Options for the client.
+ * @param {AkairoOptions} options - Options for the client.
  * @param {ClientOptions} [clientOptions] - Options for Discord JS client.
  * If not specified, the previous options parameter is used instead.
  */
 class AkairoClient extends Client {
-    constructor(options = {}, clientOptions) {
+    constructor(options, clientOptions) {
         super(clientOptions || options);
 
         const { ownerID = '' } = options;


### PR DESCRIPTION
Continuation of #216, options are required now because you need to specify the client's intents.