### PR TITLE
fix: ignore system messages on CommandHandler

### DIFF
--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -338,6 +338,10 @@ class CommandHandler extends AkairoHandler {
      * @returns {Promise<?boolean>}
      */
     async handle(message) {
+        if (message.system) {
+            return false;
+        }
+
         try {
             if (this.fetchMembers && message.guild && !message.member && !message.webhookId) {
                 await message.guild.members.fetch(message.author);


### PR DESCRIPTION
This is only a real problem if you use the `fetchMembers` option, since the member doesn't actually exist and will throw a rejection when fetched